### PR TITLE
Make pipes take a small amount of time to mine in survival

### DIFF
--- a/src/main/java/dev/technici4n/moderndynamics/pipe/PipeBlock.java
+++ b/src/main/java/dev/technici4n/moderndynamics/pipe/PipeBlock.java
@@ -59,7 +59,7 @@ public class PipeBlock extends Block implements EntityBlock, SimpleWaterloggedBl
     private boolean transparent = true;
 
     public PipeBlock(String id) {
-        super(Properties.of(Material.METAL).noOcclusion().isRedstoneConductor((state, world, pos) -> false));
+        super(Properties.of(Material.METAL).noOcclusion().isRedstoneConductor((state, world, pos) -> false).destroyTime(0.2f));
         this.id = id;
         this.registerDefaultState(this.defaultBlockState().setValue(WATERLOGGED, false));
     }


### PR DESCRIPTION
We can insta break with a wrench, insta mine on left click with no tool in survival leads to more accidental breaks than the convenience is worth.

This makes pipes take as long to break as leaves, so it's still quite fast without a tool. But this gives a little margin avoid unintentional breaks, which can be quite annoying if you have a lot of configuration on the pipe.