### PR TITLE
Fix item pipe smoothing

### DIFF
--- a/src/main/java/dev/technici4n/moderndynamics/client/ber/PipeBlockEntityRenderer.java
+++ b/src/main/java/dev/technici4n/moderndynamics/client/ber/PipeBlockEntityRenderer.java
@@ -53,7 +53,7 @@ public class PipeBlockEntityRenderer implements BlockEntityRenderer<PipeBlockEnt
                     Vec3 from, to;
                     double ratio;
 
-                    var distance = Mth.frac(item.traveledDistance()) + ClientTravelingItemSmoothing.getAndUpdateDistanceDelta(item)
+                    var distance = Mth.frac(item.traveledDistance()) + ClientTravelingItemSmoothing.getDistanceDelta(item, tickDelta)
                             + item.speed() * tickDelta;
                     if (distance <= 0.5) {
                         from = findFaceMiddle(item.in().getOpposite());

--- a/src/main/java/dev/technici4n/moderndynamics/network/item/TravelingItem.java
+++ b/src/main/java/dev/technici4n/moderndynamics/network/item/TravelingItem.java
@@ -34,6 +34,7 @@ public class TravelingItem {
     public final FailedInsertStrategy strategy;
     public final double speedMultiplier;
     public double traveledDistance;
+    public long lastTick;
 
     public TravelingItem(ItemVariant variant, int amount, ItemPath path, FailedInsertStrategy strategy, double speedMultiplier,
             double traveledDistance) {

--- a/src/main/java/dev/technici4n/moderndynamics/network/item/sync/ClientTravelingItem.java
+++ b/src/main/java/dev/technici4n/moderndynamics/network/item/sync/ClientTravelingItem.java
@@ -30,6 +30,7 @@ public final class ClientTravelingItem {
     public Direction in;
     public Direction out;
     final double speed;
+    public long lastTick;
 
     public ClientTravelingItem(int id, ItemVariant variant, int amount, double totalPathDistance, double traveledDistance, Direction in,
             Direction out, double speed) {


### PR DESCRIPTION
- Change smoothing updates to be based on client ticks instead of BER invocations.
- Make sure that traveling items only get ticked once per tick, both on the client and on the server side. This fixes jitters when an item moves from one pipe to the other, caused by the item being moved twice in the same tick.

Fixes #101.