### PR TITLE
Fix #110: Pipes correctly handle item NBT and attachments

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ curseforge_project = 552758
 modrinth_project = fMpvLrnF
 
 # Dependencies
-neoforge_version=20.4.190
+neoforge_version=20.4.235
 
 #########################################################
 # Parchment                                             #

--- a/src/main/java/dev/technici4n/moderndynamics/client/ber/FluidPipeRendering.java
+++ b/src/main/java/dev/technici4n/moderndynamics/client/ber/FluidPipeRendering.java
@@ -61,7 +61,7 @@ public class FluidPipeRendering {
             return;
         }
 
-        int color = renderProps.getTintColor(fluid.fluid().defaultFluidState(), level, pos);
+        int color = renderProps.getTintColor(fluid.getFluid().defaultFluidState(), level, pos);
         float r = ((color >> 16) & 255) / 256f;
         float g = ((color >> 8) & 255) / 256f;
         float b = (color & 255) / 256f;

--- a/src/main/java/dev/technici4n/moderndynamics/client/compat/emi/DragDropHandler.java
+++ b/src/main/java/dev/technici4n/moderndynamics/client/compat/emi/DragDropHandler.java
@@ -48,7 +48,7 @@ class DragDropHandler implements EmiDragDropHandler<Screen> {
         if (gui instanceof ItemAttachedIoScreen ioScreen && ing.getKey() instanceof Item i) {
             for (var s : ioScreen.getMenu().slots) {
                 if (s instanceof ItemConfigSlot slot && slot.isActive() && getSlotBounds(s, ioScreen).contains(mouseX, mouseY)) {
-                    var iv = ItemVariant.of(i, ing.getNbt());
+                    var iv = ItemVariant.of(ing.getItemStack());
                     ioScreen.getMenu().setFilter(slot.getConfigIdx(), iv, true);
                     return true;
                 }

--- a/src/main/java/dev/technici4n/moderndynamics/test/ItemTransferTest.java
+++ b/src/main/java/dev/technici4n/moderndynamics/test/ItemTransferTest.java
@@ -1,0 +1,58 @@
+/*
+ * Modern Dynamics
+ * Copyright (C) 2021 shartte & Technici4n
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package dev.technici4n.moderndynamics.test;
+
+import dev.technici4n.moderndynamics.init.MdBlocks;
+import dev.technici4n.moderndynamics.test.framework.MdGameTestHelper;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import net.minecraft.world.level.block.entity.HopperBlockEntity;
+
+public class ItemTransferTest {
+    @MdGameTest
+    public void testHopperInsertingDamagedItem(MdGameTestHelper helper) {
+        var targetChest = new BlockPos(0, 1, 0);
+        helper.setBlock(targetChest, Blocks.CHEST.defaultBlockState());
+        var chest = (ChestBlockEntity) helper.getBlockEntity(targetChest);
+
+        var pipe = targetChest.east();
+        helper.pipe(pipe, MdBlocks.ITEM_PIPE);
+
+        var hopper = pipe.above();
+        helper.setBlock(hopper, Blocks.HOPPER.defaultBlockState());
+
+        var damagedItem = Items.DIAMOND_PICKAXE.getDefaultInstance();
+        damagedItem.setDamageValue(500);
+        ((HopperBlockEntity) helper.getBlockEntity(hopper)).setItem(0, damagedItem.copy());
+
+        helper.startSequence()
+                .thenWaitUntil(() -> {
+                    if (chest.getItem(0).isEmpty()) {
+                        helper.fail("Expected item in chest", targetChest);
+                    }
+                    if (!ItemStack.matches(damagedItem, chest.getItem(0))) {
+                        helper.fail("Wrong item in chest", targetChest);
+                    }
+                })
+                .thenSucceed();
+    }
+}

--- a/src/main/java/dev/technici4n/moderndynamics/test/MdGameTests.java
+++ b/src/main/java/dev/technici4n/moderndynamics/test/MdGameTests.java
@@ -31,7 +31,8 @@ import net.neoforged.neoforge.gametest.GameTestHolder;
 public class MdGameTests {
     private final List<Class<?>> testClasses = List.of(
             FluidTransferTest.class,
-            ItemDistributionTest.class);
+            ItemDistributionTest.class,
+            ItemTransferTest.class);
 
     @GameTestGenerator
     public List<TestFunction> generateTests() {

--- a/src/main/java/dev/technici4n/moderndynamics/util/FluidVariantImpl.java
+++ b/src/main/java/dev/technici4n/moderndynamics/util/FluidVariantImpl.java
@@ -1,0 +1,156 @@
+/*
+ * Modern Dynamics
+ * Copyright (C) 2021 shartte & Technici4n
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package dev.technici4n.moderndynamics.util;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.material.FlowingFluid;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FluidVariantImpl implements FluidVariant {
+    private static final Map<Fluid, FluidVariant> noTagCache = new ConcurrentHashMap<>();
+
+    public static FluidVariant of(Fluid fluid, @Nullable CompoundTag nbt) {
+        Objects.requireNonNull(fluid, "Fluid may not be null.");
+
+        if (!fluid.isSource(fluid.defaultFluidState()) && fluid != Fluids.EMPTY) {
+            // Note: the empty fluid is not still, that's why we check for it specifically.
+
+            if (fluid instanceof FlowingFluid flowable) {
+                // Normalize FlowableFluids to their still variants.
+                fluid = flowable.getSource();
+            } else {
+                // If not a FlowableFluid, we don't know how to convert -> crash.
+                ResourceLocation id = BuiltInRegistries.FLUID.getKey(fluid);
+                throw new IllegalArgumentException("Cannot convert flowing fluid %s (%s) into a still fluid.".formatted(id, fluid));
+            }
+        }
+
+        if (nbt == null || fluid == Fluids.EMPTY) {
+            // Use the cached variant inside the fluid
+            return noTagCache.computeIfAbsent(fluid, f -> new FluidVariantImpl(f, null));
+        } else {
+            // TODO explore caching fluid variants for non null tags.
+            return new FluidVariantImpl(fluid, nbt);
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("fabric-transfer-api-v1/fluid");
+
+    private final Fluid fluid;
+    private final @Nullable CompoundTag nbt;
+    private final int hashCode;
+
+    public FluidVariantImpl(Fluid fluid, CompoundTag nbt) {
+        this.fluid = fluid;
+        this.nbt = nbt == null ? null : nbt.copy(); // defensive copy
+        this.hashCode = Objects.hash(fluid, nbt);
+    }
+
+    @Override
+    public boolean isBlank() {
+        return fluid == Fluids.EMPTY;
+    }
+
+    @Override
+    public Fluid getObject() {
+        return fluid;
+    }
+
+    @Override
+    public @Nullable CompoundTag getNbt() {
+        return nbt;
+    }
+
+    @Override
+    public CompoundTag toNbt() {
+        CompoundTag result = new CompoundTag();
+        result.putString("fluid", BuiltInRegistries.FLUID.getKey(fluid).toString());
+
+        if (nbt != null) {
+            result.put("tag", nbt.copy());
+        }
+
+        return result;
+    }
+
+    public static FluidVariant fromNbt(CompoundTag compound) {
+        try {
+            Fluid fluid = BuiltInRegistries.FLUID.get(new ResourceLocation(compound.getString("fluid")));
+            CompoundTag nbt = compound.contains("tag") ? compound.getCompound("tag") : null;
+            return of(fluid, nbt);
+        } catch (RuntimeException runtimeException) {
+            LOGGER.debug("Tried to load an invalid FluidVariant from NBT: {}", compound, runtimeException);
+            return FluidVariant.blank();
+        }
+    }
+
+    @Override
+    public void toPacket(FriendlyByteBuf buf) {
+        if (isBlank()) {
+            buf.writeBoolean(false);
+        } else {
+            buf.writeBoolean(true);
+            buf.writeVarInt(BuiltInRegistries.FLUID.getId(fluid));
+            buf.writeNbt(nbt);
+        }
+    }
+
+    public static FluidVariant fromPacket(FriendlyByteBuf buf) {
+        if (!buf.readBoolean()) {
+            return FluidVariant.blank();
+        } else {
+            Fluid fluid = BuiltInRegistries.FLUID.byId(buf.readVarInt());
+            CompoundTag nbt = buf.readNbt();
+            return of(fluid, nbt);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "FluidVariant{fluid=" + fluid + ", tag=" + nbt + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        // succeed fast with == check
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        FluidVariantImpl fluidVariant = (FluidVariantImpl) o;
+        // fail fast with hash code
+        return hashCode == fluidVariant.hashCode && fluid == fluidVariant.fluid && nbtMatches(fluidVariant.nbt);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+}

--- a/src/main/java/dev/technici4n/moderndynamics/util/ItemVariantImpl.java
+++ b/src/main/java/dev/technici4n/moderndynamics/util/ItemVariantImpl.java
@@ -1,0 +1,158 @@
+/*
+ * Modern Dynamics
+ * Copyright (C) 2021 shartte & Technici4n
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package dev.technici4n.moderndynamics.util;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ItemVariantImpl implements ItemVariant {
+    private static final Map<Item, ItemVariant> noTagCache = new ConcurrentHashMap<>();
+
+    public static ItemVariant of(Item item, @Nullable CompoundTag tag, @Nullable CompoundTag attachmentsTag) {
+        Objects.requireNonNull(item, "Item may not be null.");
+
+        // Only tag-less or empty item variants are cached for now.
+        if ((tag == null && attachmentsTag == null) || item == Items.AIR) {
+            return noTagCache.computeIfAbsent(item, i -> new ItemVariantImpl(i, null, null));
+        } else {
+            return new ItemVariantImpl(item, tag, attachmentsTag);
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("fabric-transfer-api-v1/item");
+
+    private final Item item;
+    private final @Nullable CompoundTag nbt;
+    private final @Nullable CompoundTag attachments;
+    private final int hashCode;
+
+    private ItemVariantImpl(Item item, CompoundTag nbt, CompoundTag attachmentsNbt) {
+        this.item = item;
+        this.nbt = nbt == null ? null : nbt.copy(); // defensive copy
+        this.attachments = attachmentsNbt == null ? null : attachmentsNbt.copy(); // defensive copy
+        hashCode = Objects.hash(item, nbt, attachmentsNbt);
+    }
+
+    @Override
+    public Item getObject() {
+        return item;
+    }
+
+    @Nullable
+    @Override
+    public CompoundTag getNbt() {
+        return nbt;
+    }
+
+    @Nullable
+    @Override
+    public CompoundTag getAttachments() {
+        return attachments;
+    }
+
+    @Override
+    public boolean isBlank() {
+        return item == Items.AIR;
+    }
+
+    @Override
+    public CompoundTag toNbt() {
+        CompoundTag result = new CompoundTag();
+        result.putString("item", BuiltInRegistries.ITEM.getKey(item).toString());
+
+        if (nbt != null) {
+            result.put("tag", nbt.copy());
+        }
+
+        if (attachments != null) {
+            result.put("attachments", attachments.copy());
+        }
+
+        return result;
+    }
+
+    public static ItemVariant fromNbt(CompoundTag tag) {
+        try {
+            Item item = BuiltInRegistries.ITEM.get(new ResourceLocation(tag.getString("item")));
+            CompoundTag aTag = tag.contains("tag") ? tag.getCompound("tag") : null;
+            CompoundTag attachmentsTag = tag.contains("attachments") ? tag.getCompound("attachments") : null;
+            return of(item, aTag, attachmentsTag);
+        } catch (RuntimeException runtimeException) {
+            LOGGER.debug("Tried to load an invalid ItemVariant from NBT: {}", tag, runtimeException);
+            return ItemVariant.blank();
+        }
+    }
+
+    @Override
+    public void toPacket(FriendlyByteBuf buf) {
+        if (isBlank()) {
+            buf.writeBoolean(false);
+        } else {
+            buf.writeBoolean(true);
+            buf.writeVarInt(Item.getId(item));
+            buf.writeNbt(nbt);
+            buf.writeNbt(attachments);
+        }
+    }
+
+    public static ItemVariant fromPacket(FriendlyByteBuf buf) {
+        if (!buf.readBoolean()) {
+            return ItemVariant.blank();
+        } else {
+            Item item = Item.byId(buf.readVarInt());
+            CompoundTag nbt = buf.readNbt();
+            CompoundTag attachments = buf.readNbt();
+            return of(item, nbt, attachments);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ItemVariant{item=" + item + ", tag=" + nbt + ", attachments=" + attachments + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        // succeed fast with == check
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        ItemVariantImpl ItemVariant = (ItemVariantImpl) o;
+        // fail fast with hash code
+        return hashCode == ItemVariant.hashCode && item == ItemVariant.item && nbtMatches(ItemVariant.nbt)
+                && Objects.equals(attachments, ItemVariant.attachments);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+}

--- a/src/main/java/dev/technici4n/moderndynamics/util/TransferVariant.java
+++ b/src/main/java/dev/technici4n/moderndynamics/util/TransferVariant.java
@@ -1,0 +1,103 @@
+/*
+ * Modern Dynamics
+ * Copyright (C) 2021 shartte & Technici4n
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package dev.technici4n.moderndynamics.util;
+
+import java.util.Objects;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * An immutable association of an immutable object instance (for example {@code Item} or {@code Fluid}) and an optional NBT tag.
+ *
+ * <p>
+ * This is exposed for convenience for code that needs to be generic across multiple transfer variants,
+ * but note that a {@link Storage} is not necessarily bound to {@code TransferVariant}. Its generic parameter can be any immutable object.
+ *
+ * <p>
+ * <b>Transfer variants must always be compared with {@code equals}, never by reference!</b>
+ * {@code hashCode} is guaranteed to be correct and constant time independently of the size of the NBT.
+ *
+ * @param <O> The type of the immutable object instance, for example {@code Item} or {@code Fluid}.
+ */
+public interface TransferVariant<O> {
+    /**
+     * Return true if this variant is blank, and false otherwise.
+     */
+    boolean isBlank();
+
+    /**
+     * Return the immutable object instance of this variant.
+     */
+    O getObject();
+
+    /**
+     * Return the underlying tag.
+     *
+     * <p>
+     * <b>NEVER MUTATE THIS NBT TAG</b>, if you need to mutate it you can use {@link #copyNbt()} to retrieve a copy instead.
+     */
+    @Nullable
+    CompoundTag getNbt();
+
+    /**
+     * Return true if the tag of this variant matches the passed tag, and false otherwise.
+     *
+     * <p>
+     * Note: True is returned if both tags are {@code null}.
+     */
+    default boolean nbtMatches(@Nullable CompoundTag other) {
+        return Objects.equals(getNbt(), other);
+    }
+
+    /**
+     * Return {@code true} if the object of this variant matches the passed fluid.
+     */
+    default boolean isOf(O object) {
+        return getObject() == object;
+    }
+
+    /**
+     * Return a copy of the tag of this variant, or {@code null} if this variant doesn't have a tag.
+     *
+     * <p>
+     * Note: Use {@link #nbtMatches} if you only need to check for custom tag equality, or {@link #getNbt()} if you don't need to mutate the tag.
+     */
+    @Nullable
+    default CompoundTag copyNbt() {
+        CompoundTag nbt = getNbt();
+        return nbt == null ? null : nbt.copy();
+    }
+
+    /**
+     * Save this variant into an NBT compound tag. Subinterfaces should have a matching static {@code fromNbt}.
+     *
+     * <p>
+     * Note: This is safe to use for persisting data as objects are saved using their full Identifier.
+     */
+    CompoundTag toNbt();
+
+    /**
+     * Write this variant into a packet byte buffer. Subinterfaces should have a matching static {@code fromPacket}.
+     *
+     * <p>
+     * Implementation note: Objects are saved using their raw registry integer id.
+     */
+    void toPacket(FriendlyByteBuf buf);
+}


### PR DESCRIPTION
This PR copies the variant handling from MI. This is quite heavy-handed, but will be useful for the 1.20.6 port.